### PR TITLE
Update GitHub Actions workflows to use latest action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,40 +35,29 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Build
-        uses: pypa/cibuildwheel@v3.3.0
+        uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
           CIBW_ARCHS: ${{ matrix.archs || 'auto' }}
           
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pitct-${{ runner.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
           retention-days: 7
       
       - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@2.11.2
+        uses: svenstaro/upload-release-action@2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./wheelhouse/*.whl
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true
-
-      # - name: Upload binaries to pytct-docs release
-      #   uses: svenstaro/upload-release-action@v2
-      #   with:
-      #     repo_token: ${{ secrets.PYTCT_DOCS_RELEASE_TOKEN }}
-      #     file: ./wheelhouse/*.whl
-      #     tag: ${{ github.ref }}
-      #     overwrite: true
-      #     file_glob: true
-      #     repo_name: OMUCAI/PyTCT-docs
-      #     body: ${{ github.event.release.body }}
           
   build-sdist:
     # The type of runner that the job will run on
@@ -77,20 +66,20 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - name: Build
         run: pipx run build --sdist
           
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pitct-sdist
           path: dist
           retention-days: 7
           
       - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/*.tar.gz
@@ -111,7 +100,7 @@ jobs:
     
     steps:
       - name: Download regular platform artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: pitct-*
           path: dist

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -35,16 +35,16 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.0
+        uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
           CIBW_ARCHS: ${{ matrix.archs || 'auto' }}
           
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pitct-${{ runner.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -52,24 +52,13 @@ jobs:
       
       # Test: Skip uploading to release for test runs
       # - name: Upload binaries to release
-      #   uses: svenstaro/upload-release-action@v2
+      #   uses: svenstaro/upload-release-action@2.11.5
       #   with:
       #     repo_token: ${{ secrets.GITHUB_TOKEN }}
       #     file: ./wheelhouse/*.whl
       #     tag: ${{ github.ref }}
       #     overwrite: true
       #     file_glob: true
-
-      # - name: Upload binaries to pytct-docs release
-      #   uses: svenstaro/upload-release-action@v2
-      #   with:
-      #     repo_token: ${{ secrets.PYTCT_DOCS_RELEASE_TOKEN }}
-      #     file: ./wheelhouse/*.whl
-      #     tag: ${{ github.ref }}
-      #     overwrite: true
-      #     file_glob: true
-      #     repo_name: OMUCAI/PyTCT-docs
-      #     body: ${{ github.event.release.body }}
           
   build-sdist:
     # The type of runner that the job will run on
@@ -78,13 +67,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - name: Build
         run: pipx run build --sdist
           
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pitct-sdist
           path: dist
@@ -92,7 +81,7 @@ jobs:
           
       # Test: Skip uploading to release for test runs
       # - name: Upload binaries to release
-      #   uses: svenstaro/upload-release-action@v2
+      #   uses: svenstaro/upload-release-action@2.11.5
       #   with:
       #     repo_token: ${{ secrets.GITHUB_TOKEN }}
       #     file: dist/*.tar.gz
@@ -113,7 +102,7 @@ jobs:
 
     steps:
       - name: Download regular platform artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: pitct-*
           path: dist


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for both release and release testing to use the latest versions of several key actions. These changes help ensure improved security, new features, and better maintenance by keeping dependencies up-to-date.

**CI/CD workflow action updates:**

* Updated `actions/checkout` from v5 to v6 in both `release.yml` and `release_test.yml` for all jobs. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L38-R82) [[2]](diffhunk://#diff-4dbeb46fb23b5e0a6848000fed331c0a8d0b7c81c2ae45a0ad9fa889458c7097L38-R84)
* Updated `actions/upload-artifact` from v4 to v7 in both workflows, and from v4 to v7 for sdist jobs. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L38-R82) [[2]](diffhunk://#diff-4dbeb46fb23b5e0a6848000fed331c0a8d0b7c81c2ae45a0ad9fa889458c7097L38-R84)
* Updated `actions/download-artifact` from v5 to v8 for artifact download steps. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L114-R103) [[2]](diffhunk://#diff-4dbeb46fb23b5e0a6848000fed331c0a8d0b7c81c2ae45a0ad9fa889458c7097L116-R105)

**Build and release tool updates:**

* Updated `pypa/cibuildwheel` from v3.3.0 to v3.4.1 for building wheels. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L38-R82) [[2]](diffhunk://#diff-4dbeb46fb23b5e0a6848000fed331c0a8d0b7c81c2ae45a0ad9fa889458c7097L38-R84)
* Updated `svenstaro/upload-release-action` from v2 (and v2.11.2) to v2.11.5 for uploading binaries to releases (including commented-out steps). [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L38-R82) [[2]](diffhunk://#diff-4dbeb46fb23b5e0a6848000fed331c0a8d0b7c81c2ae45a0ad9fa889458c7097L38-R84)

No workflow logic or behavior was changed—these are version bumps to keep the CI/CD pipeline current.